### PR TITLE
Use Alpine version of JDK image

### DIFF
--- a/appd-machine/Dockerfile
+++ b/appd-machine/Dockerfile
@@ -1,19 +1,19 @@
-FROM openjdk:8-jre-slim AS builder
+FROM openjdk:8u151-jre-alpine3.7 AS builder
 
-MAINTAINER mark.prichard@appdynamics.com
-
-ARG APPD_AGENT_VERSION 
+ARG APPD_AGENT_VERSION
 ARG APPD_AGENT_SHA256
 
 COPY MachineAgent-${APPD_AGENT_VERSION}.zip /
 RUN echo "${APPD_AGENT_SHA256} *MachineAgent-${APPD_AGENT_VERSION}.zip" >> appd_checksum \
     && sha256sum -c appd_checksum \
     && rm appd_checksum \
-    && unzip -oq MachineAgent-${APPD_AGENT_VERSION}.zip -d /tmp 
+    && mkdir /tmp/unzip \
+    && unzip -oq MachineAgent-${APPD_AGENT_VERSION}.zip -d /tmp/unzip
 
 
-FROM openjdk:8-jre-slim
-RUN apt-get update && apt-get -y upgrade && apt-get install -y unzip && apt-get install -y apt-utils && apt-get install -y iproute2 && apt-get install -y procps && apt-get install -y sysstat
-COPY --from=builder /tmp /opt/appdynamics
+FROM openjdk:8u151-jre-alpine3.7
+RUN apk add --no-cache iproute2 procps sysstat dumb-init
+COPY --from=builder /tmp/unzip /opt/appdynamics
 
+ENTRYPOINT ["/usr/bin/dumb-init"]
 CMD ["sh", "-c", "java ${MACHINE_AGENT_PROPERTIES} -jar /opt/appdynamics/machineagent.jar"]

--- a/appd-machine/Dockerfile
+++ b/appd-machine/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "${APPD_AGENT_SHA256} *MachineAgent-${APPD_AGENT_VERSION}.zip" >> appd_
 
 
 FROM openjdk:8u151-jre-alpine3.7
-RUN apk add --no-cache iproute2 procps sysstat dumb-init
+RUN apk add --no-cache iproute2 procps sysstat dumb-init bash coreutils
 COPY --from=builder /tmp/unzip /opt/appdynamics
 
 ENTRYPOINT ["/usr/bin/dumb-init"]


### PR DESCRIPTION
Also, use /tmp/unzip in case of extra files, and include dumb-init.

Further comments:
Original Line 3: MAINTAINER instruction is deprecated
Diff Line 18: dumb-init helps reap child processes and handle signals sent to the container (and is very small).

Here's the size difference from my local build:
```
alpine-appd 218MB
debian-appd 396MB
```