### PR TITLE
Update startup.sh

### DIFF
--- a/appd-db-agent/startup.sh
+++ b/appd-db-agent/startup.sh
@@ -30,5 +30,5 @@ fi
 
 
 
-# Start Machine Agent
-java ${DB_PROPERTIES} -jar ${DB_AGENT_HOME}/db-agent.jar
+# Start Database Agent
+java -jar ${DB_AGENT_HOME}/db-agent.jar ${DB_PROPERTIES}


### PR DESCRIPTION
Agent appears to hang when started using: java ${DB_PROPERTIES} -jar ${DB_AGENT_HOME}/db-agent.jar
Agent starts correctly when startup is modified to: java -jar ${DB_AGENT_HOME}/db-agent.jar ${DB_PROPERTIES}